### PR TITLE
gs인증 관련 브릿지 추가 에러  문구 수정

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2819,7 +2819,7 @@ PageNetworkBridgeSettings.prototype = {
                         .catch(function (error) {
                             let err_txt = "입력하신 설정 정보가 올바르지 않습니다. 다시 확인 후 입력해 주세요.";
                             if (error.message.includes("ipv4.method:") || error.toString().includes("ipv4.method:")) {
-                                err_txt = "브릿지 이름 중복 또는 포트 선택이 올바르지 않습니다. 설정을 확인해 주세요.";
+                                err_txt = "브릿지 이름 중복 또는 포트 선택이 올바르지 않습니다. 설정을 확인하신 후 현재 창을 닫고 다시 실행해 주세요. (현재 창에서는 더 이상 해당 기능이 동작하지 않습니다.)";
                             } else if (error.message.includes("connection.id:") || error.toString().includes("connection.id:")) {
                                 err_txt = "브릿지 이름을 입력해 주세요.";
                             }


### PR DESCRIPTION
"브릿지 이름 중복 또는 포트 선택이 올바르지 않습니다. 설정을 확인해 주세요."을

"브릿지 이름 중복 또는 포트 선택이 올바르지 않습니다. 설정을 확인하신 후 현재 창을 닫고 다시 실행해 주세요. (현재 창에서는 더이상 해당 기능이 동작하지 않습니다.)" 으로

수정